### PR TITLE
Database agnosticism (REGEXP)

### DIFF
--- a/EventCalendar.php
+++ b/EventCalendar.php
@@ -133,7 +133,14 @@ function renderEventCalendar( $input, $args, $mwParser ) {
     $options = array();
 
     $where['page_namespace'] = $namespaceIndex;
-    $where[] = "page_title REGEXP '^[0-9]{4}/[0-9]{2}/[0-9]{2}_[[:alnum:]]'";
+
+    if ( $dbr instanceof DatabasePostgres ) {
+        $regexp_op = '~';
+    } else {
+        $regexp_op = 'REGEXP';
+    }
+
+    $where[] = "page_title " . $regexp_op . " '^[0-9]{4}/[0-9]{2}/[0-9]{2}_[[:alnum:]]'";
 
     $options['ORDER BY'] = 'page_title DESC';
     $options['LIMIT'] = 5000; // should limit output volume to about 300 KiB

--- a/EventCalendar.php
+++ b/EventCalendar.php
@@ -132,15 +132,17 @@ function renderEventCalendar( $input, $args, $mwParser ) {
     $where = array();
     $options = array();
 
-    $where['page_namespace'] = $namespaceIndex;
+    if ( ! $dbr instanceof DatabaseSqlite ) {
+        $where['page_namespace'] = $namespaceIndex;
 
-    if ( $dbr instanceof DatabasePostgres ) {
-        $regexp_op = '~';
-    } else {
-        $regexp_op = 'REGEXP';
+        if ( $dbr instanceof DatabasePostgres ) {
+            $regexp_op = '~';
+        } else {
+            $regexp_op = 'REGEXP';
+        }
+
+        $where[] = "page_title " . $regexp_op . " '^[0-9]{4}/[0-9]{2}/[0-9]{2}_[[:alnum:]]'";
     }
-
-    $where[] = "page_title " . $regexp_op . " '^[0-9]{4}/[0-9]{2}/[0-9]{2}_[[:alnum:]]'";
 
     $options['ORDER BY'] = 'page_title DESC';
     $options['LIMIT'] = 5000; // should limit output volume to about 300 KiB
@@ -151,6 +153,14 @@ function renderEventCalendar( $input, $args, $mwParser ) {
 
     $eventmap = array();
     foreach ( $res as $row ) {
+
+        if ( $dbr instanceof DatabaseSqlite ) {
+            if( ! preg_match('@^[0-9]{4}/[0-9]{2}/[0-9]{2}_.*@', $row->page_title)) {
+                continue;  // Ignoring page titles that don't follow the 
+                           // pattern of event pages
+            } 
+        }
+
         $date = str_replace( '/', '-', substr( $row->page_title, 0, 10 ));
         $title = str_replace( '_', ' ', substr( $row->page_title, 11 ));
         $url = Title::makeTitle( $namespaceIndex, $row->page_title )->getLinkURL();

--- a/EventCalendar.php
+++ b/EventCalendar.php
@@ -139,8 +139,9 @@ function renderEventCalendar( $input, $args, $mwParser ) {
     $where = array();
     $options = array();
 
+    $where['page_namespace'] = $namespaceIndex;
+
     if ( ! $dbr instanceof DatabaseSqlite ) {
-        $where['page_namespace'] = $namespaceIndex;
 
         if ( $dbr instanceof DatabasePostgres ) {
             $regexp_op = '~';

--- a/EventCalendar.php
+++ b/EventCalendar.php
@@ -141,6 +141,8 @@ function renderEventCalendar( $input, $args, $mwParser ) {
 
     $where['page_namespace'] = $namespaceIndex;
 
+    $title_pattern = '^[0-9]{4}/[0-9]{2}/[0-9]{2}_[[:alnum:]]';
+
     if ( ! $dbr instanceof DatabaseSqlite ) {
 
         if ( $dbr instanceof DatabasePostgres ) {
@@ -149,7 +151,7 @@ function renderEventCalendar( $input, $args, $mwParser ) {
             $regexp_op = 'REGEXP';
         }
 
-        $where[] = "page_title " . $regexp_op . " '^[0-9]{4}/[0-9]{2}/[0-9]{2}_[[:alnum:]]'";
+        $where[] = "page_title " . $regexp_op . " '" . $title_pattern . "'";
     }
 
     $options['ORDER BY'] = 'page_title DESC';
@@ -163,7 +165,7 @@ function renderEventCalendar( $input, $args, $mwParser ) {
     foreach ( $res as $row ) {
 
         if ( $dbr instanceof DatabaseSqlite ) {
-            if( ! preg_match('@^[0-9]{4}/[0-9]{2}/[0-9]{2}_.*@', $row->page_title)) {
+            if( ! preg_match("@" . $title_pattern . "@", $row->page_title)) {
                 continue;  // Ignoring page titles that don't follow the 
                            // pattern of event pages
             } 


### PR DESCRIPTION
Fixes #1

I didn' t find a way to use the PDO method sqliteCreateFunction (http://www.php.net/manual/en/pdo.sqlitecreatefunction.php) to define REGEXP in SQLite. To be able to do that, I need to have access to the protected property _mConn_ of _DatabaseSqlite_ class.

The solution I found is to retrieve all page titles and check with PHP function preg_match if the title is from an event. It will be slower than a direct search in database, but I can't find a better way.

For working in PostgreSQL I just set the right regex operator based on _DatabaseBase_ subclass.
