### PR TITLE
Customizing the language and localization for the calendar

### DIFF
--- a/EventCalendar.php
+++ b/EventCalendar.php
@@ -45,7 +45,8 @@ $wgResourceModules['ext.yasec'] = array(
     'scripts' => array(
         'fullcalendar/lib/moment.min.js',
         'fullcalendar/fullcalendar/fullcalendar.min.js',
-        'ext.yasec.core.js',
+        'fullcalendar/fullcalendar/lang/all.js',
+		'ext.yasec.core.js',
     ),
     'styles' => array(
         'fullcalendar/fullcalendar/fullcalendar.css',
@@ -109,6 +110,7 @@ function renderEventCalendar( $input, $args, $mwParser ) {
     // defaults
     $aspectRatio = 1.6;
     $namespaceIndex = 0;
+    $lang = 'en';
 
     $parameters = explode( "\n", $input );
 
@@ -122,6 +124,9 @@ function renderEventCalendar( $input, $args, $mwParser ) {
         switch ( $type ) {
             case 'aspectratio':
                 $aspectRatio = floatval( $arg );
+                break;
+            case 'lang':
+                $lang = $arg;
                 break;
             case 'namespace':
                 $ns = $wgContLang->getNsIndex( $arg );
@@ -195,6 +200,8 @@ function renderEventCalendar( $input, $args, $mwParser ) {
         "<script>\n" .
         "if ( typeof window.eventCalendarAspectRatio !== 'object' ) { window.eventCalendarAspectRatio = []; }\n" .
         "window.eventCalendarAspectRatio.push( {$aspectRatio} );\n" .
+        "if ( typeof window.eventCalendarLang !== 'object' ) { window.eventCalendarLang = []; }\n" .
+        "window.eventCalendarLang.push( '{$lang}' );\n" .
         "if ( typeof window.eventCalendarData !== 'object' ) { window.eventCalendarData = []; }\n" .
         "window.eventCalendarData.push( " . json_encode( $events ) . " );\n" .
         "</script>\n";

--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ Typical invocation on a page:
     <EventCalendar>
     namespace = Event
     aspectratio = 1.35
+    lang = en
     </EventCalendar>
 
 `aspectratio` is optional and defaults to 1.6. CSS `max-width` is set to
 800px and can be overridden in `MediaWiki:Common.css`.
+
+`lang` is optional and defaults to en. Other languages code options can
+be found in /resources/fullcalendar/fullcalendar/lang directory
 
 ### Requirements
 

--- a/resources/ext.yasec.core.js
+++ b/resources/ext.yasec.core.js
@@ -4,7 +4,8 @@ jQuery( document ).ready( function( $ ) {
             // render calendar
             $( "#eventcalendar-" + ( i + 1 )).fullCalendar({
                 aspectRatio: window.eventCalendarAspectRatio[i],
-                events: window.eventCalendarData[i]
+                events: window.eventCalendarData[i],
+                lang: window.eventCalendarLang[i]
             });
 
             // FIXME sometimes init is called too early, it seems, so rerender to be sure


### PR DESCRIPTION
FullCalendar library has a property to customize the language and localization options for the calendar:
http://arshaw.com/fullcalendar/docs2/text/lang/

This commit adds the support for using this customization property.
