### PR TITLE
Changed DB_SLAVE to DB_REPLICA to match MW 1.27+

### DIFF
--- a/EventCalendar.php
+++ b/EventCalendar.php
@@ -133,7 +133,7 @@ function renderEventCalendar( $input, $args, $mwParser ) {
     } // end foreach()
 
     // build the SQL query
-    $dbr = wfGetDB( DB_SLAVE );
+    $dbr = wfGetDB( DB_REPLICA );
     $tables = array( 'page' );
     $fields = array( 'page_title' );
     $where = array();

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Typical invocation on a page:
 ### Requirements
 
 * MediaWiki 1.22 (will probably work with other versions, comments
-  appreciated)
+  appreciated) tested with MW 1.34.2
 * MySQL (see [#1][4])
 
 ### Installation


### PR DESCRIPTION
MW 1.34 now enforces the DB_REPLICA semantic. Updated to work with 1.34. Tested with 1.34.2.